### PR TITLE
Update dependencies (Gemnasium auto-update 08b06d187dd3fc37e01c4ebae86de8cd025826e9)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     workless (2.2.0)
       delayed_job (>= 2.0.7)
       platform-api


### PR DESCRIPTION
Update dependencies:
websocket-extensions: 0.1.2 => 0.1.3