### PR TITLE
Update dependencies (Gemnasium auto-update 3da35e1df98b0d43f74825db6b34b616c9327fa2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.6.0)
+    active_interaction (3.6.1)
       activemodel (>= 4, < 6)
     active_model_serializers (0.10.6)
       actionpack (>= 4.1, < 6)
@@ -377,7 +377,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     workless (2.2.0)
       delayed_job (>= 2.0.7)
       platform-api


### PR DESCRIPTION
Update dependencies:
active_interaction: 3.6.0 => 3.6.1
websocket-extensions: 0.1.2 => 0.1.3