### PR TITLE
Update dependencies (Gemnasium auto-update 60c1bb45eab49b92390c4df371a807a7fe5995b9)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.6.0)
+    active_interaction (3.6.1)
       activemodel (>= 4, < 6)
     active_model_serializers (0.10.6)
       actionpack (>= 4.1, < 6)
@@ -54,7 +54,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    appsignal (2.4.0)
+    appsignal (2.4.1)
       rack
     archive-zip (0.7.0)
       io-like (~> 0.3.0)
@@ -68,7 +68,7 @@ GEM
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
-    capybara (2.15.4)
+    capybara (2.16.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
@@ -104,7 +104,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
-    crass (1.0.2)
+    crass (1.0.3)
     d3-rails (3.5.17)
       railties (>= 3.1)
     daemons (1.2.5)
@@ -225,7 +225,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
-    public_suffix (3.0.0)
+    public_suffix (3.0.1)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.6.3)
@@ -266,7 +266,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    react-rails (2.4.1)
+    react-rails (2.4.2)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -377,7 +377,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     workless (2.2.0)
       delayed_job (>= 2.0.7)
       platform-api


### PR DESCRIPTION
Update dependencies:
capybara: 2.15.4 => 2.16.0
public_suffix: 3.0.0 => 3.0.1
appsignal: 2.4.0 => 2.4.1
active_interaction: 3.6.0 => 3.6.1
react-rails: 2.4.1 => 2.4.2
crass: 1.0.2 => 1.0.3
websocket-extensions: 0.1.2 => 0.1.3