### PR TITLE
Catch any email errors (just dont send when it crashes)

### DIFF
--- a/app/use_cases/send_invitation.rb
+++ b/app/use_cases/send_invitation.rb
@@ -15,8 +15,13 @@ class SendInvitation < ActiveInteraction::Base
 
   def send_email(email, message, invitation_url)
     return unless email.present?
-    mailer = InvitationMailer.invitation_mail(email, message, invitation_url)
-    mailer.deliver_now
+    begin
+      mailer = InvitationMailer.invitation_mail(email, message, invitation_url)
+      mailer.deliver_now
+    rescue StandardError => e
+      Rails.logger.warn "[Attention] Mailgun failed again: #{e.message}"
+      Rails.logger.warn e.backtrace.inspect
+    end
   end
 
   def send_sms_attributes

--- a/spec/use_cases/send_invitation_spec.rb
+++ b/spec/use_cases/send_invitation_spec.rb
@@ -167,44 +167,6 @@ describe SendInvitation do
         described_class.run!(response: response)
       end
 
-      it 'should also send the invitation via email' do
-        protocol_subscription = FactoryGirl.create(:protocol_subscription,
-                                                   person: mentor,
-                                                   filling_out_for: student,
-                                                   start_date: 1.week.ago.at_beginning_of_day)
-        dagboek = FactoryGirl.create(:questionnaire, name: 'dagboek')
-        measurement = FactoryGirl.create(:measurement, questionnaire: dagboek)
-        response = FactoryGirl.create(:response, protocol_subscription: protocol_subscription,
-                                                 measurement: measurement)
-        FactoryGirl.create(:invitation_token, response: response)
-        mytok = response.invitation_token.token
-        message = 'Fijn dat je wilt helpen om inzicht te krijgen in de ontwikkeling van jongeren! ' \
-          'Vul nu de eerste wekelijkse vragenlijst in.'
-
-        allow(SendSms).to receive(:run!)
-        invitation_url = "#{ENV['HOST_URL']}/?q=#{mytok}"
-        expect(InvitationMailer).to receive(:invitation_mail).with(mentor.email,
-                                                                   message,
-                                                                   invitation_url).and_call_original
-        described_class.run!(response: response)
-        expect(ActionMailer::Base.deliveries.last.to.first).to eq mentor.email
-      end
-
-      it 'should not try to send an email if the mentor does not have an email address' do
-        mentor.update_attributes!(email: nil)
-        protocol_subscription = FactoryGirl.create(:protocol_subscription,
-                                                   person: mentor,
-                                                   filling_out_for: student,
-                                                   start_date: 1.week.ago.at_beginning_of_day)
-        dagboek = FactoryGirl.create(:questionnaire, name: 'dagboek')
-        measurement = FactoryGirl.create(:measurement, questionnaire: dagboek)
-        response = FactoryGirl.create(:response, protocol_subscription: protocol_subscription,
-                                                 measurement: measurement)
-        FactoryGirl.create(:invitation_token, response: response)
-        allow(SendSms).to receive(:run!)
-        expect(InvitationMailer).to_not receive(:invitation_mail)
-      end
-
       it 'should send the second text if the questionnaire is not a voormeting and it is not the first one' do
         protocol_subscription = FactoryGirl.create(:protocol_subscription,
                                                    person: mentor,
@@ -231,6 +193,68 @@ describe SendInvitation do
                                                text: smstext,
                                                reference: "vsv-#{response.id}")
         described_class.run!(response: response)
+      end
+
+      describe 'send mails' do
+        it 'should not raise if the mail sending fails' do
+          questionnaire = FactoryGirl.create(:questionnaire, name: 'de voormeting vragenlijst')
+          response.measurement = FactoryGirl.create(:measurement, questionnaire: questionnaire)
+          FactoryGirl.create(:invitation_token, response: response)
+          allow(SendSms).to receive(:run!).with(any_args).and_return true
+          allow(InvitationMailer).to receive(:invitation_mail).and_raise(RuntimeError, 'Crashing')
+          expect { described_class.run!(response: response) }.to_not raise_error
+        end
+
+        it 'should call the logger if anything fails' do
+          questionnaire = FactoryGirl.create(:questionnaire, name: 'de voormeting vragenlijst')
+          response.measurement = FactoryGirl.create(:measurement, questionnaire: questionnaire)
+          FactoryGirl.create(:invitation_token, response: response)
+          allow(SendSms).to receive(:run!).with(any_args).and_return true
+          message = 'crashing'
+          allow(InvitationMailer).to receive(:invitation_mail).and_raise(RuntimeError, message)
+          expect(Rails.logger).to receive(:warn).with("[Attention] Mailgun failed again: #{message}").once
+          expect(Rails.logger).to receive(:warn).with(any_args).once
+
+          described_class.run!(response: response)
+        end
+
+        it 'should also send the invitation via email' do
+          protocol_subscription = FactoryGirl.create(:protocol_subscription,
+                                                     person: mentor,
+                                                     filling_out_for: student,
+                                                     start_date: 1.week.ago.at_beginning_of_day)
+          dagboek = FactoryGirl.create(:questionnaire, name: 'dagboek')
+          measurement = FactoryGirl.create(:measurement, questionnaire: dagboek)
+          response = FactoryGirl.create(:response, protocol_subscription: protocol_subscription,
+                                                   measurement: measurement)
+          FactoryGirl.create(:invitation_token, response: response)
+          mytok = response.invitation_token.token
+          message = 'Fijn dat je wilt helpen om inzicht te krijgen in de ontwikkeling van jongeren! ' \
+            'Vul nu de eerste wekelijkse vragenlijst in.'
+
+          allow(SendSms).to receive(:run!)
+          invitation_url = "#{ENV['HOST_URL']}/?q=#{mytok}"
+          expect(InvitationMailer).to receive(:invitation_mail).with(mentor.email,
+                                                                     message,
+                                                                     invitation_url).and_call_original
+          described_class.run!(response: response)
+          expect(ActionMailer::Base.deliveries.last.to.first).to eq mentor.email
+        end
+
+        it 'should not try to send an email if the mentor does not have an email address' do
+          mentor.update_attributes!(email: nil)
+          protocol_subscription = FactoryGirl.create(:protocol_subscription,
+                                                     person: mentor,
+                                                     filling_out_for: student,
+                                                     start_date: 1.week.ago.at_beginning_of_day)
+          dagboek = FactoryGirl.create(:questionnaire, name: 'dagboek')
+          measurement = FactoryGirl.create(:measurement, questionnaire: dagboek)
+          response = FactoryGirl.create(:response, protocol_subscription: protocol_subscription,
+                                                   measurement: measurement)
+          FactoryGirl.create(:invitation_token, response: response)
+          allow(SendSms).to receive(:run!)
+          expect(InvitationMailer).to_not receive(:invitation_mail)
+        end
       end
     end
   end


### PR DESCRIPTION
Is dit iets wat we willen? dan sturen we nooit mail als het mis gaat met mailgun. We sturen dan dus ook geen 2 smsjes als er iets mis gaat met mailen. Een soort temp fix voordat we die invitation set hebben.