### PR TITLE
Allow a mentor to unsubscribe from a protocol subscription

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -10,6 +10,7 @@ MESSAGEBIRD_ACCESS_KEY:                 live_accesskey
 MESSAGEBIRD_SEND_FROM:                  u-can-act
 
 PERSON_SALT:                            some_salt
+STOP_SUBSCRIPTION_SALT:                 9c2787d9be7bfb748cc2058b7df3feefa2800cfc3a45f9b3b507b50a92640f2f864bd107477337dc024c7998fefff8101ab8b91e2bc282d57277a4cdceec38b4
 
 ADMIN_USERNAME:                         admin
 ADMIN_PASSWORD:                         admin

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Required and allowed options (minimal example and maximal example):
    { title: 'De relatie verbeteren en/of onderhouden', shows_questions: %i[v2 v3] },
    { title: 'Inzicht krijgen in de belevingswereld', tooltip: 'de belevingswereld van de student', hides_questions: %i[v4 v5] },
    'Inzicht krijgen in de omgeving',
-   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9] },
+   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9], stop_subscription: true },
    { title: 'Vaardigheden ontwikkelen', shows_questions: %i[v10 v11] },
    { title: 'De omgeving veranderen/afstemmen met de omgeving', shows_questions: %i[v12] }
   ],
@@ -216,9 +216,11 @@ Required and allowed options (minimal example and maximal example):
 }]
 ```
 
-The options array can contain either hashes or strings. If it is just a string, it is used as the `title` element. The `show_otherwise` field is optional, and determines whether or not the question should have an 'otherwise' field. The `tooltip' field is also optional. When present, it will introduce a small i on which the user can click to get extra information (the information in the tooltip variable).
+The options array can contain either hashes or strings. If it is just a string, it is used as the `title` element. The `show_otherwise` field is optional, and determines whether or not the question should have an 'otherwise' field. The `tooltip` field is also optional. When present, it will introduce a small i on which the user can click to get extra information (the information in the tooltip variable).
 
-Note that the `shows_questions` and `hides_questions` fields require the corresponding questions to have the `hidden: true` and `hidden: false` properties, respectively. For example:
+In the options array, the `stop_subscription: true` property indicates that the protocol subscription should be canceled when this option is selected. 
+
+Note that the `shows_questions` and `hides_questions` option properties require the corresponding questions to have the `hidden: true` and `hidden: false` properties, respectively. For example:
 
 ```ruby
 [{
@@ -257,7 +259,7 @@ Required and allowed options (minimal example and maximal example):
    { title: 'De relatie verbeteren en/of onderhouden', shows_questions: %i[v2 v3] },
    { title: 'Inzicht krijgen in de belevingswereld', hides_questions: %i[v4 v5] },
    'Inzicht krijgen in de omgeving',
-   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9] },
+   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9], stop_subscription: true },
    { title: 'Vaardigheden ontwikkelen', tooltip: 'Zoals wiskunde', shows_questions: %i[v10 v11] },
    { title: 'De omgeving veranderen/afstemmen met de omgeving', shows_questions: %i[v12] }
   ],
@@ -270,7 +272,7 @@ Required and allowed options (minimal example and maximal example):
 
 The options array can contain either hashes or strings. If it is just a string, it is used as the `title` element.  The `show_otherwise` field is optional, and determines whether or not the question should have an 'otherwise' field. The `tooltip' field is also optional. When present, it will introduce a small i on which the user can click to get extra information (the information in the tooltip variable).
 
-Note that the `shows_questions` and `hides_questions` fields here work identically to those described above in the Type: Checkbox section.
+Note that the `shows_questions`, `hides_questions`, and `stop_subscription` option properties here work identically to those described above in the Type: Checkbox section.
 
 Radios are always required.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The .env.local file is used for storing all ENV variables. Below is a list of al
   MESSAGEBIRD_SEND_FROM: <sender name shown for SMS>
 
   PERSON_SALT: <salt used to hash person ids in the exporter>
+  STOP_SUBSCRIPTION_SALT: <salt used for hashing the stop_subscription keys>
 
   ADMIN_USERNAME: <user name for the admin panel>
   ADMIN_PASSWORD: <password for the admin panel>

--- a/app/assets/javascripts/questionnaire_logic.js.erb
+++ b/app/assets/javascripts/questionnaire_logic.js.erb
@@ -21,7 +21,7 @@ function toggle_otherwise_field() {
 function show_hide_entry(entry, show) {
   var klass = '.' + entry + '_toggle';
   if (show) {
-    $(klass).removeClass('hidden').find('input:visible,textarea:visible').prop('disabled', false);
+    $(klass).removeClass('hidden').find('input:visible,textarea:visible,input[type=hidden]').prop('disabled', false);
     $('.otherwise-option').each(toggle_otherwise_field);
   } else {
     $(klass).addClass('hidden').find('input,textarea').prop('disabled', true);

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -37,10 +37,9 @@ class QuestionnaireController < ApplicationController
     stop_subscription_hash = questionnaire_stop_subscription
     content = questionnaire_content
     should_stop = false
-    stop_subscription_hash.each do |key, value|
+    stop_subscription_hash.each do |key, received|
       next unless content.key?(key)
       expected = Response.stop_subscription_token(key, content[key], @response.id)
-      received = value
       are_equal = ActiveSupport::SecurityUtils.secure_compare(expected, received)
       if are_equal
         should_stop = true

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -38,23 +38,29 @@ class QuestionnaireController < ApplicationController
     content = questionnaire_content
     should_stop = false
     stop_subscription_hash.each do |key, value|
-      next unless content.has_key?(key)
+      next unless content.key?(key)
       expected = Response.stop_subscription_token(key, content[key], @response.id)
       received = value
-      are_equal = ActiveSupport::SecurityUtils::secure_compare(expected,received)
+      are_equal = ActiveSupport::SecurityUtils.secure_compare(expected, received)
       if are_equal
         should_stop = true
         break
       end
     end
     return unless should_stop
+    stop_protocol_subscription
+  end
+
+  def stop_protocol_subscription
     @response.protocol_subscription.cancel!
     flash[:notice] = if @response.protocol_subscription.mentor?
-                       "Succes: De begeleiding voor #{@response.protocol_subscription.filling_out_for.first_name} is gestopt."
+                       "Succes: De begeleiding voor #{@response.protocol_subscription.filling_out_for.first_name} " \
+                       'is gestopt.'
                      else
                        'Succes: Je hebt je voor de dagboekstudie uitgeschreven. Bedankt voor je deelname!'
                      end
-    Rails.logger.error "[Attention] Protocol subscription #{@response.protocol_subscription.id} was stopped by person #{@response.protocol_subscription.person_id}."
+    Rails.logger.error "[Attention] Protocol subscription #{@response.protocol_subscription.id} was stopped by " \
+                       "person #{@response.protocol_subscription.person_id}."
   end
 
   def check_content_hash

--- a/app/models/protocol_subscription.rb
+++ b/app/models/protocol_subscription.rb
@@ -29,6 +29,10 @@ class ProtocolSubscription < ApplicationRecord
     state == ACTIVE_STATE
   end
 
+  def cancel!
+    update_attributes!(state: CANCELED_STATE, end_date: Time.zone.now)
+  end
+
   def ended?
     Time.zone.now > end_date
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -53,6 +53,10 @@ class Response < ApplicationRecord
     where('open_from > :time_now', time_now: Time.zone.now)
   })
 
+  def self.stop_subscription_token(answer_key, answer_value, response_id)
+    Digest::SHA256.hexdigest("#{answer_key}|#{answer_value}|#{response_id}|#{ENV['STOP_SUBSCRIPTION_SALT']}")
+  end
+
   # rubocop:disable Metrics/AbcSize
   def self.in_week(options = {})
     raise('Only :week_number and :year are valid options!') unless (options.keys - %i[week_number year]).blank?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,11 @@
         .card-panel.alert.red.lighten-2
           %strong Let op:
           Je browser heeft momenteel JavaScript uitstaan. Daardoor werkt deze app niet goed.
+    - flash.each do |name, msg|
+      .row
+        .col.s12
+          .card-panel.green{class: name}
+            %span.white-text= msg
     .container
       .row
         = yield

--- a/db/seeds/questionnaires/mentor_diary.rb
+++ b/db/seeds/questionnaires/mentor_diary.rb
@@ -23,7 +23,8 @@ dagboek_content = [{
     'Ik heb deze week geen contact gehad met {{deze_student}}.',
     { title: 'Ik ben gestopt met de begeleiding van {{deze_student}}.',
       shows_questions: %i[v14 v15],
-      stop_subscription: true },
+      stop_subscription: true,
+      tooltip: 'Let op: als je deze optie selecteert word je hierna niet meer gevraagd om vragenlijsten in te vullen over {{deze_student}}.' },
     { title: '{{Deze_student}} is gestopt met de opleiding.',
       shows_questions: %i[v16 v17 v18] },
     { title: 'Ik heb de begeleiding van {{deze_student}} overgedragen aan iemand anders.',
@@ -199,7 +200,9 @@ dagboek_content = [{
   type: :radio,
   title: 'Stopt jouw begeleiding van {{deze_student}} nu {{hij_zij_student}} met de opleiding is gestopt?',
   options: [
-    { title: 'Ja', stop_subscription: true },
+    { title: 'Ja',
+      stop_subscription: true,
+      tooltip: 'Let op: als je deze optie selecteert word je hierna niet meer gevraagd om vragenlijsten in te vullen over {{deze_student}}.' },
     'Nee'
   ]
 }]

--- a/db/seeds/questionnaires/mentor_diary.rb
+++ b/db/seeds/questionnaires/mentor_diary.rb
@@ -21,10 +21,13 @@ dagboek_content = [{
   title: 'Waarom heb je deze week geen acties ondernomen in de begeleiding van {{deze_student}}?',
   options: [
     'Ik heb deze week geen contact gehad met {{deze_student}}.',
-    'Ik ben gestopt met de begeleiding van {{deze_student}}.',
-    '{{Deze_student}} is gestopt met de opleiding.',
+    { title: 'Ik ben gestopt met de begeleiding van {{deze_student}}.',
+      shows_questions: %i[v14 v15],
+      stop_subscription: true },
+    { title: '{{Deze_student}} is gestopt met de opleiding.',
+      shows_questions: %i[v16 v17 v18] },
     { title: 'Ik heb de begeleiding van {{deze_student}} overgedragen aan iemand anders.',
-      shows_questions: %i[v10 v11 v12] }
+      shows_questions: %i[v10 v11 v12 v13] }
   ]
 }, {
   id: :v3, # 2
@@ -159,6 +162,46 @@ dagboek_content = [{
   hidden: true,
   type: :textarea,
   title: 'Wat denk jij dat diegene deze week heeft gedaan in de begeleiding van {{deze_student}}?'
+}, {
+  id: :v13,
+  hidden: true,
+  type: :raw,
+  content: '<p class="flow-text section-explanation">Is de overdracht van begeleiding van permanente aard? Mail dan de telefoonnummers van jou, {{deze_student}} en de nieuwe begeleider naar <a href="mailto:n.r.snell@rug.nl">n.r.snell@rug.nl</a>.</p>'
+}, {
+  id: :v14,
+  hidden: true,
+  type: :textarea,
+  title: 'Waarom ben je gestopt met de begeleiding van {{deze_student}}?',
+}, {
+  id: :v15,
+  hidden: true,
+  type: :radio,
+  title: 'Denk jij dat {{deze_student}} nog steeds risico loopt om voortijdig te stoppen met {{zijn_haar_student}} opleiding?',
+  options: %w[Ja Nee]
+}, {
+  id: :v16,
+  hidden: true,
+  type: :textarea,
+  title: 'Waarom is {{deze_student}} gestopt met {{zijn_haar_student}} opleiding?',
+}, {
+  id: :v17,
+  hidden: true,
+  type: :radio,
+  title: 'Wat gaat {{deze_student}} doen nu {{hij_zij_student}} gestopt is met {{zijn_haar_student}} opleiding?',
+  options: [
+    'Werken',
+    'Een andere opleiding volgen',
+    'Weet ik niet'
+  ]
+}, {
+  id: :v18,
+  hidden: true,
+  type: :radio,
+  title: 'Stopt jouw begeleiding van {{deze_student}} nu {{hij_zij_student}} met de opleiding is gestopt?',
+  options: [
+    { title: 'Ja', stop_subscription: true },
+    'Nee'
+  ]
 }]
 dagboek1.content = dagboek_content
 dagboek1.title = db_title

--- a/spec/generators/questionnaire_generator_spec.rb
+++ b/spec/generators/questionnaire_generator_spec.rb
@@ -32,7 +32,7 @@ describe QuestionnaireGenerator do
       }]
       expect do
         described_class.send(:questionnaire_questions,
-                             questionnaire_content)
+                             questionnaire_content, nil)
       end.to raise_error(RuntimeError, 'Unknown question type asdf')
     end
   end


### PR DESCRIPTION
Allow a mentor to unsubscribe from a protocol subscription while leaving the protocol subscription for the student running.



![chrome_2018-02-20_23-56-09](https://user-images.githubusercontent.com/607965/36453784-a7345936-1699-11e8-922d-5eba24802a6d.png)


**Don't forget to run seeds after deploying**