### PR TITLE
Remove responses after end_date for canceled subscriptions

### DIFF
--- a/app/models/protocol_subscription.rb
+++ b/app/models/protocol_subscription.rb
@@ -46,6 +46,7 @@ class ProtocolSubscription < ApplicationRecord
 
   def cancel!
     update_attributes!(state: CANCELED_STATE, end_date: Time.zone.now)
+    responses.future.destroy_all
   end
 
   def ended?


### PR DESCRIPTION
En dan dit eenmalig in de console draaien:
```ruby
ProtocolSubscription.where(state: ProtocolSubscription::CANCELED_STATE).find_each do |protsub|
  protsub.responses.where('open_from > :end_date', end_date: protsub.end_date).destroy_all!
end
```