### PR TITLE
[16432795] Move url to the questionnaire spec, instead of the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,13 +479,14 @@ The `min` and `max` properties can be either two arrays as in the above example,
 Please note that there is currently a bug in the date picker when you specify dates as arrays. So if you want june 14th, as a start date, use [2018, 5, 14], i.e., subtract one from the month.
 
 ### Type: Unsubscribe
-Including an unsubscribe question type will display a card that allows the user to unsubscribe from the protocol. Typically, you want only one `unsubscribe` question in your questionnaire, as the first item in the questionnaire. You may want to control its visibility by specifying a `show_after` property.
+Including an unsubscribe question type will display a card that allows the user to unsubscribe from the protocol. Typically, you want only one `unsubscribe` question in your questionnaire, as the first item in the questionnaire. You may want to control its visibility by specifying a `show_after` property. The `unsubscribe_url` should be a url that accepts a `DELETE` request, and which should deal with stopping the protocol subscription (mandatory).
 
 Required and allowed options (minimal example):
 
 ```ruby
 [{
   type: :unsubscribe,
+  unsubscribe_url: Rails.application.routes.url_helpers.questionnaire_path(uuid: ''),
   title: 'Klaar met dit schooljaar?',
   content: 'Ben je klaar met dit schooljaar? Klik dan op de knop \'Onderzoek afronden\' om het onderzoek te voltooien.',
   button_text: 'Onderzoek afronden',

--- a/app/generators/questionnaire_generator.rb
+++ b/app/generators/questionnaire_generator.rb
@@ -704,7 +704,11 @@ class QuestionnaireGenerator
     def generate_unsubscribe_action(question)
       response = Response.find_by_id(question[:response_id])
       url_href = '#'
-      url_href = Rails.application.routes.url_helpers.questionnaire_path(uuid: response.uuid) if response
+      if response
+        url_href = "#{question[:unsubscribe_url]}
+                    #{question[:unsubscribe_url].ends_with?('/') ? '' : '/'}
+                    #{response.uuid}"
+      end
       body = content_tag(:a, (question[:button_text] || 'Uitschrijven').html_safe,
                          'data-method': 'delete',
                          href: url_href,

--- a/db/seeds/questionnaires/student_diary.rb
+++ b/db/seeds/questionnaires/student_diary.rb
@@ -11,6 +11,7 @@ dagboek_content = [{
                      title: 'Klaar met dit schooljaar?',
                      content: 'Ben je klaar met dit schooljaar? Klik dan op de knop \'Onderzoek afronden\' om het onderzoek te voltooien. Zo nee, vul dan gewoon de onderstaande vragenlijst in.',
                      button_text: 'Onderzoek afronden',
+                     unsubscribe_url: Rails.application.routes.url_helpers.questionnaire_path(uuid: ''),
                      show_after: (Rails.env.development? ? 1.second.ago : Time.new(2018, 6, 27).in_time_zone)
                    }, {
                      section_start: 'School en Stage',


### PR DESCRIPTION
Dit lost het probleem op van de Rails app dependency in questionnaire_generator. Ik vraag me nog wel af of het zo precies is wat we willen. Dit zorgt er namelijk wel voor dat een questionnaire een dependency houdt op een bepaalde vsv-backend (met het oog op serverless). Dat betekent dus dat we voor elke backend een andere vragenlijst aan moeten maken.

Wat misschien een betere optie zou zijn is om het in de call naar de server(less) een unsubscribe url mee te geven. Het punt is dat het dan weer wat moeilijk generiek wordt. Wat denk jij hiervan? Misschien ook iets voor de meeting a.s. maandag.