### PR TITLE
[14105458] Added newlines in html emails

### DIFF
--- a/app/views/invitation_mailer/invitation_mail.html.haml
+++ b/app/views/invitation_mailer/invitation_mail.html.haml
@@ -1,4 +1,4 @@
-%h3 #{@message}
+%h3 #{@message.gsub("\n", "<br>").html_safe}
 %p Klik op de volgende link om de vragenlijsten in te vullen:
 %p
   =link_to @invitation_url, style: 'text-decoration: none; background-color:#243a76;-webkit-border-radius:25px;-moz-border-radius:25px;border-radius:25px;display:inline-block;color:#fff;padding:0 20px;-webkit-box-shadow:0 0 0 10px rgba(255,255,255,0.8);-moz-box-shadow:0 0 0 10px rgba(255,255,255,0.8);box-shadow:0 0 0 10px rgba(255,255,255,0.8)' do

--- a/app/views/invitation_mailer/invitation_mail.html.haml
+++ b/app/views/invitation_mailer/invitation_mail.html.haml
@@ -1,5 +1,4 @@
-%h3 #{@message.gsub("\n", "<br>").html_safe}
-%p Klik op de volgende link om de vragenlijsten in te vullen:
+%p #{@message.gsub("\n", "<br>").html_safe}
 %p
   =link_to @invitation_url, style: 'text-decoration: none; background-color:#243a76;-webkit-border-radius:25px;-moz-border-radius:25px;border-radius:25px;display:inline-block;color:#fff;padding:0 20px;-webkit-box-shadow:0 0 0 10px rgba(255,255,255,0.8);-moz-box-shadow:0 0 0 10px rgba(255,255,255,0.8);box-shadow:0 0 0 10px rgba(255,255,255,0.8)' do
     %span{style:"line-height:50px"}Vul de vragenlijsten in


### PR DESCRIPTION
__Dit was het:__
![mailcatcher 7 2018-07-09 11-15-06](https://user-images.githubusercontent.com/617574/42441807-5765ce7a-8369-11e8-8519-9609c42dba0b.png)

__Dit is het nu:__
![mailcatcher 5 2018-07-09 11-14-27](https://user-images.githubusercontent.com/617574/42441767-40af5ee4-8369-11e8-9ce0-5c9eb77c8d34.png)

__Aangeroepen met:__
``` ruby
reload!; mailer = InvitationMailer.invitation_mail('a@a.com', "Deze tekst heeft\nenters", "toktok").deliver_now
```

