### PR TITLE
Fixed sms stuff

### DIFF
--- a/app/logic/invitation_texts.rb
+++ b/app/logic/invitation_texts.rb
@@ -67,8 +67,8 @@ class InvitationTexts
     private
 
     def in_announcement_week?
-      Time.zone.now > Time.new(2018, 7, 18).in_time_zone &&
-        Time.zone.now < Time.new(2018, 7, 25).in_time_zone
+      Time.zone.now > Time.new(2018, 7, 24).in_time_zone &&
+        Time.zone.now < Time.new(2018, 8, 1).in_time_zone
     end
 
     def post_assessment?(response)

--- a/app/logic/mentor_invitation_texts.rb
+++ b/app/logic/mentor_invitation_texts.rb
@@ -11,13 +11,15 @@ class MentorInvitationTexts < InvitationTexts
 
     def announcement_week_texts(response)
       if post_assessment?(response)
-        return "Hoi #{target_first_name(response)}, wij willen net als jij "\
-               'graag vsv voorkomen. Wil jij ons voor de laatste keer helpen'\
-               ' en de laatste, maar cruciale, u-can-act vragenlijst invullen?'
+        return "Hoi #{target_first_name(response)}, wij willen net als jij graag vsv voorkomen."\
+          ' Wil jij ons voor de laatste keer helpen en de laatste, maar cruciale,'\
+          ' u-can-act vragenlijst invullen?'
       end
       "Hoi #{target_first_name(response)}, de allerlaatste vragenlijsten"\
-        ' staan voor je klaar. Voor ons is het ontzettend belangrijk dat'\
-        ' deze wordt ingevuld. Help jij ons voor de laatste keer?'
+      ' staan voor je klaar. Voor ons is het ontzettend belangrijk dat deze'\
+      " wordt ingevuld. Help jij ons voor de laatste keer?\n"\
+      'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
+      ' vragenlijst een stuk korter dan je gewend bent .'
     end
 
     def normal_texts(response)

--- a/app/logic/student_invitation_texts.rb
+++ b/app/logic/student_invitation_texts.rb
@@ -177,8 +177,8 @@ class StudentInvitationTexts < InvitationTexts
       if post_assessment?(response)
         return '{{deze_student}}, wil jij jouw beloning ontvangen? Dit is de laatste'\
         ' kans om jouw IBAN in te vullen en alleen dan kunnen wij jou uitbetalen.'\
-          ' Het zou zonde zijn om jouw gevulde u-can-act spaarpot niet te innen,'\
-          ' toch?'
+        ' Het zou zonde zijn om jouw gevulde u-can-act spaarpot niet te innen,'\
+        ' toch?'
       end
 
       'Hoi {{deze_student}}, wil je je beloning ontvangen? Geef dan je IBAN'\

--- a/app/logic/student_invitation_texts.rb
+++ b/app/logic/student_invitation_texts.rb
@@ -175,14 +175,17 @@ class StudentInvitationTexts < InvitationTexts
 
     def announcement_week_texts(response)
       if post_assessment?(response)
-        return '{{deze_student}}, wil jij jouw beloning ontvangen?' \
-        ' Vul dan de laatste vragenlijst in, alleen dan kunnen wij je' \
-        ' uitbetalen. Het zou zonde zijn om jouw gevulde u-can-act spaarpot' \
-        ' niet te innen, toch?'
+        return '{{deze_student}}, wil jij jouw beloning ontvangen? Dit is de laatste'\
+        ' kans om jouw IBAN in te vullen en alleen dan kunnen wij jou uitbetalen.'\
+          ' Het zou zonde zijn om jouw gevulde u-can-act spaarpot niet te innen,'\
+          ' toch?'
       end
-      'Hoi {{deze_student}}, vul je de laatste vragenlijst in,' \
-      ' waar je ook je IBAN nummer kan invullen? Let op: alleen '\
-      ' dan kunnen wij jouw beloning uitbetalen.'
+
+      'Hoi {{deze_student}}, wil je je beloning ontvangen? Geef dan je IBAN'\
+      ' nummer aan ons door. Alleen dan kunnen wij jouw beloning uitbetalen.'\
+      " Dit kan je doen door de laatste vragenlijst in te vullen.\n"\
+      'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
+      ' vragenlijst een stuk korter dan je gewend bent .'
     end
   end
 end

--- a/app/use_cases/reschedule_responses.rb
+++ b/app/use_cases/reschedule_responses.rb
@@ -26,6 +26,8 @@ class RescheduleResponses < ActiveInteraction::Base
   def schedule_responses_for_measurement(measurement)
     measurement.response_times(protocol_subscription.start_date, protocol_subscription.end_date).each do |time|
       next if time <= future
+      next if protocol_subscription.responses.completed.where(measurement_id: measurement.id).present? && 
+        !measurement.periodical?
       Response.create!(protocol_subscription_id: protocol_subscription.id,
                        measurement_id: measurement.id,
                        open_from: time)

--- a/app/use_cases/reschedule_responses.rb
+++ b/app/use_cases/reschedule_responses.rb
@@ -25,12 +25,20 @@ class RescheduleResponses < ActiveInteraction::Base
 
   def schedule_responses_for_measurement(measurement)
     measurement.response_times(protocol_subscription.start_date, protocol_subscription.end_date).each do |time|
-      next if time <= future
-      next if protocol_subscription.responses.completed.where(measurement_id: measurement.id).present? && 
-        !measurement.periodical?
+      next if current_or_past_time? time
+      next if measurement_response_completed_and_not_periodical?
       Response.create!(protocol_subscription_id: protocol_subscription.id,
                        measurement_id: measurement.id,
                        open_from: time)
     end
+  end
+
+  def current_or_past_time?(time)
+    time <= future
+  end
+
+  def measurement_response_completed_and_not_periodical?
+    protocol_subscription.responses.completed.where(measurement_id: measurement.id).present? &&
+      !measurement.periodical?
   end
 end

--- a/spec/logic/mentor_invitation_texts_spec.rb
+++ b/spec/logic/mentor_invitation_texts_spec.rb
@@ -21,7 +21,7 @@ describe MentorInvitationTexts do
 
   describe 'In the anouncement week' do
     before :each do
-      Timecop.freeze(2018, 7, 19)
+      Timecop.freeze(2018, 7, 26)
     end
 
     after :each do
@@ -45,7 +45,9 @@ describe MentorInvitationTexts do
                                               measurement: measurement1,
                                               open_from: 1.minute.ago)
       expected = 'Hoi Jane, de allerlaatste vragenlijsten staan voor je klaar. Voor ons is het ontzettend belangrijk' \
-                 ' dat deze wordt ingevuld. Help jij ons voor de laatste keer?'
+                 " dat deze wordt ingevuld. Help jij ons voor de laatste keer?\n"\
+                 'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
+                 ' vragenlijst een stuk korter dan je gewend bent .'
       result = described_class.message(response)
       expect(result).to eq(expected)
     end

--- a/spec/logic/student_invitation_texts_spec.rb
+++ b/spec/logic/student_invitation_texts_spec.rb
@@ -14,7 +14,7 @@ describe StudentInvitationTexts do
   describe 'message' do
     describe 'in announcement week' do
       before :each do
-        Timecop.freeze(2018, 7, 19)
+        Timecop.freeze(2018, 7, 26)
       end
       after :each do
         Timecop.return
@@ -33,9 +33,11 @@ describe StudentInvitationTexts do
       end
 
       it 'should return the normal text if the response is not a post assessment' do
-        expected = 'Hoi {{deze_student}}, vul je de laatste vragenlijst in,' \
-                   ' waar je ook je IBAN nummer kan invullen? Let op: alleen '\
-                   ' dan kunnen wij jouw beloning uitbetalen.'
+        expected = 'Hoi {{deze_student}}, wil je je beloning ontvangen? Geef dan je IBAN'\
+                    ' nummer aan ons door. Alleen dan kunnen wij jouw beloning uitbetalen.'\
+                    " Dit kan je doen door de laatste vragenlijst in te vullen.\n"\
+                    'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
+                    ' vragenlijst een stuk korter dan je gewend bent .'
         response = FactoryBot.create(:response, protocol_subscription: protocol_subscription,
                                                 measurement: measurement2,
                                                 completed_at: nil,

--- a/spec/use_cases/reschedule_responses_spec.rb
+++ b/spec/use_cases/reschedule_responses_spec.rb
@@ -75,5 +75,102 @@ describe RescheduleResponses do
       described_class.run!(protocol_subscription: protocol_subscription, future: future)
       expect(Response.count).to eq(2)
     end
+
+    describe 'rescheduling single time measurements' do
+      let(:protocol) { FactoryBot.create(:protocol, duration: 5.weeks) }
+      let!(:measurement) do
+        FactoryBot.create(:measurement, protocol: protocol,
+                                        open_from_offset: nil,
+                                        offset_till_end: 2.days + 12.hours,
+                                        period: nil,
+                                        open_duration: nil,
+                                        reward_points:  0,
+                                        stop_measurement: true,
+                                        should_invite: true,
+                                        redirect_url: '/person/edit')
+      end
+
+      let!(:protocol_subscription) do
+        FactoryBot.create(:protocol_subscription,
+                          protocol: protocol,
+                          start_date: 1.week.ago.at_beginning_of_day,
+                          end_date: 3.days.from_now)
+      end
+      before :each do
+        Timecop.freeze(2018, 7, 26)
+      end
+
+      after :each do
+        Timecop.return
+      end
+
+      it 'should reschedule not future responses for non periodical measurements if they is one completed ' do
+        # Using the student nameting as an example
+        Response.destroy_all
+
+        # Create finished response
+        finished_response = Response.create!(protocol_subscription_id: protocol_subscription.id,
+                                             measurement_id: measurement.id,
+                                             completed_at: 7.days.ago.in_time_zone,
+                                             open_from: 8.days.ago.in_time_zone)
+
+        expect_any_instance_of(Measurement).to receive(:response_times).with(
+          protocol_subscription.start_date,
+          protocol_subscription.end_date
+        ).and_call_original
+
+        expect(Response.count).to eq(1)
+        described_class.run!(protocol_subscription: protocol_subscription)
+        expect(Response.count).to eq(1)
+        expect(Response.all.first).to eq finished_response
+      end
+
+      it 'should reschedule future responses for non periodical measurements if there are none completed ' do
+        Response.destroy_all
+
+        expect_any_instance_of(Measurement).to receive(:response_times).with(
+          protocol_subscription.start_date,
+          protocol_subscription.end_date
+        ).and_call_original
+
+        expect(Response.count).to eq(0)
+        described_class.run!(protocol_subscription: protocol_subscription)
+        expect(Response.count).to eq(1)
+        expect(Response.all.first.measurement).to eq measurement
+        expect(Response.all.first.protocol_subscription).to eq protocol_subscription
+      end
+
+      fit 'should reschedule not future responses for non periodical measurements if they is one completed ' do
+        protocol.reload
+        protocol.measurements.destroy_all
+        measurement = FactoryBot.create(:measurement, :periodical, 
+                                        protocol: protocol,
+                                        open_duration: 10.weeks,
+                                        reward_points:  0,
+                                        should_invite: true,
+                                        redirect_url: '/person/edit')
+        Response.destroy_all
+
+        protocol.reload
+        expect(protocol.measurements.length).to eq 1
+
+        # Create finished response
+        finished_response = Response.create!(protocol_subscription_id: protocol_subscription.id,
+                                             measurement_id: measurement.id,
+                                             completed_at: 7.days.ago.in_time_zone,
+                                             open_from: 8.days.ago.in_time_zone)
+
+        expect_any_instance_of(Measurement).to receive(:response_times).with(
+          protocol_subscription.start_date,
+          protocol_subscription.end_date
+        ).and_call_original
+
+        expect(Response.count).to eq(1)
+        expect(protocol_subscription.responses.count).to eq(1)
+
+        described_class.run!(protocol_subscription: protocol_subscription)
+        expect(Response.count).to eq(2)
+      end
+    end
   end
 end

--- a/spec/use_cases/reschedule_responses_spec.rb
+++ b/spec/use_cases/reschedule_responses_spec.rb
@@ -140,10 +140,10 @@ describe RescheduleResponses do
         expect(Response.all.first.protocol_subscription).to eq protocol_subscription
       end
 
-      fit 'should reschedule not future responses for non periodical measurements if they is one completed ' do
+      it 'should reschedule not future responses for non periodical measurements if they is one completed ' do
         protocol.reload
         protocol.measurements.destroy_all
-        measurement = FactoryBot.create(:measurement, :periodical, 
+        measurement = FactoryBot.create(:measurement, :periodical,
                                         protocol: protocol,
                                         open_duration: 10.weeks,
                                         reward_points:  0,
@@ -170,6 +170,8 @@ describe RescheduleResponses do
 
         described_class.run!(protocol_subscription: protocol_subscription)
         expect(Response.count).to eq(2)
+        expect(Response.all.first.protocol_subscription).to eq protocol_subscription
+        expect(Response.all.second.protocol_subscription).to_not eq protocol_subscription
       end
     end
   end


### PR DESCRIPTION
# Description of feature
Allows for rescheduling measurements

# Checklist
- [x] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [x] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.

# Code to run on production
__!!EERST DE RESCHEDULE JOB UITZETTEN!!__
```
measurements = Questionnaire.where('name LIKE ?', "%nameting%").map{|x| x.measurements}.flatten;nil
# Is this correct?
measurements.count == 7
responses = measurements.map{|m| m.responses.select{|x| !x.completed?}};nil
protocol_subscriptions  = responses.map{|x| x.protocol_subscription};nil
protocol_subscriptions.each do |prot_sub|
    RescheduleResponses.run!(protocol_subscription: protocol_subscription)
end
```