### PR TITLE
Update announcement week

### DIFF
--- a/app/logic/invitation_texts.rb
+++ b/app/logic/invitation_texts.rb
@@ -67,8 +67,8 @@ class InvitationTexts
     private
 
     def in_announcement_week?
-      Time.zone.now > Time.new(2018, 7, 24).in_time_zone &&
-        Time.zone.now < Time.new(2018, 8, 1).in_time_zone
+      Time.zone.now > Time.new(2018, 8, 1).in_time_zone &&
+        Time.zone.now < Time.new(2018, 8, 8).in_time_zone
     end
 
     def post_assessment?(response)

--- a/app/logic/student_invitation_texts.rb
+++ b/app/logic/student_invitation_texts.rb
@@ -173,19 +173,10 @@ class StudentInvitationTexts < InvitationTexts
 
     private
 
-    def announcement_week_texts(response)
-      if post_assessment?(response)
-        return '{{deze_student}}, wil jij jouw beloning ontvangen? Dit is de laatste'\
-        ' kans om jouw IBAN in te vullen en alleen dan kunnen wij jou uitbetalen.'\
-        ' Het zou zonde zijn om jouw gevulde u-can-act spaarpot niet te innen,'\
-        ' toch?'
-      end
-
-      'Hoi {{deze_student}}, wil je je beloning ontvangen? Geef dan je IBAN'\
-      ' nummer aan ons door. Alleen dan kunnen wij jouw beloning uitbetalen.'\
-      " Dit kan je doen door de laatste vragenlijst in te vullen.\n"\
-      'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
-      ' vragenlijst een stuk korter dan je gewend bent .'
+    def announcement_week_texts(_response)
+      'Hoi {{deze_student}}, je hebt geld verdiend met je deelname aan u-can-act: dit'\
+      ' is je laatste kans om te innen! Vul de laatste vragenlijst en IBAN in,'\
+      ' alleen dan kunnen we je beloning overmaken.'
     end
   end
 end

--- a/app/views/mentor_overview/index.html.haml
+++ b/app/views/mentor_overview/index.html.haml
@@ -8,7 +8,7 @@
     = current_user.first_name
     = current_user.last_name
 
-- if Time.zone.now < Time.new(2018, 8, 1).in_time_zone && current_user.protocol_subscriptions.active.count.positive?
+- if Time.zone.now < Time.new(2018, 9, 1).in_time_zone && current_user.protocol_subscriptions.active.count.positive?
   .row.section
     .col.s12= QuestionnaireGenerator.send(:generate_unsubscribe, { type: :unsubscribe,
                                   title: 'Klaar met dit schooljaar?',

--- a/spec/logic/mentor_invitation_texts_spec.rb
+++ b/spec/logic/mentor_invitation_texts_spec.rb
@@ -21,7 +21,7 @@ describe MentorInvitationTexts do
 
   describe 'In the anouncement week' do
     before :each do
-      Timecop.freeze(2018, 7, 26)
+      Timecop.freeze(2018, 8, 2)
     end
 
     after :each do

--- a/spec/logic/student_invitation_texts_spec.rb
+++ b/spec/logic/student_invitation_texts_spec.rb
@@ -14,31 +14,17 @@ describe StudentInvitationTexts do
   describe 'message' do
     describe 'in announcement week' do
       before :each do
-        Timecop.freeze(2018, 7, 26)
+        Timecop.freeze(2018, 8, 2)
       end
+
       after :each do
         Timecop.return
       end
 
-      it 'should return the post_assessment text if the response is a post assessment' do
-        expected = '{{deze_student}}, wil jij jouw beloning ontvangen? Dit is de laatste'\
-        ' kans om jouw IBAN in te vullen en alleen dan kunnen wij jou uitbetalen.'\
-        ' Het zou zonde zijn om jouw gevulde u-can-act spaarpot niet te innen,'\
-        ' toch?'
-        response = FactoryBot.create(:response, protocol_subscription: protocol_subscription,
-                                                measurement: measurement3,
-                                                completed_at: nil,
-                                                open_from: 1.minute.ago)
-        result = described_class.message(response)
-        expect(result).to eq(expected)
-      end
-
-      it 'should return the normal text if the response is not a post assessment' do
-        expected = 'Hoi {{deze_student}}, wil je je beloning ontvangen? Geef dan je IBAN'\
-                    ' nummer aan ons door. Alleen dan kunnen wij jouw beloning uitbetalen.'\
-                    " Dit kan je doen door de laatste vragenlijst in te vullen.\n"\
-                    'Ps. Door aan te geven dat je inmiddels vakantie hebt, wordt de'\
-                    ' vragenlijst een stuk korter dan je gewend bent .'
+      it 'should return correct text' do
+        expected = 'Hoi {{deze_student}}, je hebt geld verdiend met je deelname'\
+        ' aan u-can-act: dit is je laatste kans om te innen! Vul de laatste'\
+        ' vragenlijst en IBAN in, alleen dan kunnen we je beloning overmaken.'
         response = FactoryBot.create(:response, protocol_subscription: protocol_subscription,
                                                 measurement: measurement2,
                                                 completed_at: nil,


### PR DESCRIPTION
# Description of feature
We need to send out new invitation texts in this specific week. I've updated them here.

# Checklist
- [x] Updated unit tests to test the code.

# Code to run
``` ruby
people = Person.where("iban IS NULL").select{|x| !x.mentor? && x.protocol_subscriptions.sum(&:earned_euros) > 0 }
protocol_subscriptions = people.map{|x| x.protocol_subscriptions}.flatten

protocol_subscriptions.each do |prot_sub|
    # Note: We zetten hier ook mensen op active die actief gecancelled zijn (misschien door ons)
    prot_sub.update_attributes!(end_date: Time.zone.parse("6-8-2018 0:00"), state: 'active')
    RescheduleResponses.run!(protocol_subscription: prot_sub, future: 1.minute.from_now.in_time_zone)
end
```