### PR TITLE
Fix CSRF errors when submitting answers for questionnaires

### DIFF
--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -216,6 +216,7 @@ class QuestionnaireController < ApplicationController
   end
 
   def log_csrf_error
+    return unless protect_against_forgery? # is false in test environment
     return if valid_request_origin? && any_authenticity_token_valid?
     record_warning_in_rails_logger
     params['content']['csrf_failed'] = 'true' if params['content'].present?

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -3,7 +3,8 @@
 class QuestionnaireController < ApplicationController
   MAX_ANSWER_LENGTH = 2048
   include Concerns::IsLoggedIn
-  rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_auth_token
+  protect_from_forgery prepend: true, with: :exception, except: :create
+  before_action :log_csrf_error, only: %i[create]
   before_action :set_response, only: %i[show destroy]
   # TODO: verify cookie for show as well
   before_action :store_response_cookie, only: %i[show]
@@ -214,7 +215,14 @@ class QuestionnaireController < ApplicationController
     redirect_to NextPageFinder.get_next_page current_user: current_user
   end
 
-  def invalid_auth_token
+  def log_csrf_error
+    return if valid_request_origin? && any_authenticity_token_valid?
+    record_warning_in_rails_logger
+    params['content']['csrf_failed'] = 'true' if params['content'].present?
+  end
 
+  def record_warning_in_rails_logger
+    Rails.logger.warn "[Attention] CSRF error for user #{current_user&.id} at " \
+                      "#{request.fullpath} with params: #{params.pretty_inspect}"
   end
 end

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -3,6 +3,7 @@
 class QuestionnaireController < ApplicationController
   MAX_ANSWER_LENGTH = 2048
   include Concerns::IsLoggedIn
+  rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_auth_token
   before_action :set_response, only: %i[show destroy]
   # TODO: verify cookie for show as well
   before_action :store_response_cookie, only: %i[show]
@@ -211,5 +212,9 @@ class QuestionnaireController < ApplicationController
     return if !response.expired? || response.measurement.stop_measurement
     flash[:notice] = 'Deze vragenlijst kan niet meer ingevuld worden.'
     redirect_to NextPageFinder.get_next_page current_user: current_user
+  end
+
+  def invalid_auth_token
+
   end
 end

--- a/spec/controllers/questionnaire_controller_spec.rb
+++ b/spec/controllers/questionnaire_controller_spec.rb
@@ -227,17 +227,28 @@ RSpec.describe QuestionnaireController, type: :controller do
         expect(responseobj.values).to eq('v1' => 'true')
       end
 
-      it 'logs an attention message and adds a key to the answers when authenticity token fails' do
-        expect_any_instance_of(described_class).to receive(:verify_cookie)
-        protocol_subscription = FactoryBot.create(:protocol_subscription, start_date: 1.week.ago.at_beginning_of_day)
-        responseobj = FactoryBot.create(:response, protocol_subscription: protocol_subscription, open_from: 1.hour.ago)
-        expect(Rails.logger).to receive(:warn).with(/^\[Attention\]/)
-        post :create, params: { response_id: responseobj.id, content: { 'v1' => 'true' }, authenticity_token: 'lol' }
-        expect(response).to have_http_status(302)
-        responseobj.reload
-        expect(responseobj.completed_at).to be_within(1.minute).of(Time.zone.now)
-        expect(responseobj.content).to_not be_nil
-        expect(responseobj.values).to eq('v1' => 'true', 'csrf_failed' => 'true')
+      context 'request forgery protection' do
+        before do
+          ActionController::Base.allow_forgery_protection = true
+        end
+        after do
+          ActionController::Base.allow_forgery_protection = false
+        end
+        it 'logs an attention message and adds a key to the answers when authenticity token fails' do
+          expect_any_instance_of(described_class).to receive(:verify_cookie)
+          protocol_subscription = FactoryBot.create(:protocol_subscription,
+                                                    start_date: 1.week.ago.at_beginning_of_day)
+          responseobj = FactoryBot.create(:response,
+                                          protocol_subscription: protocol_subscription,
+                                          open_from: 1.hour.ago)
+          expect(Rails.logger).to receive(:warn).with(/^\[Attention\]/)
+          post :create, params: { response_id: responseobj.id, content: { 'v1' => 'true' } }
+          expect(response).to have_http_status(302)
+          responseobj.reload
+          expect(responseobj.completed_at).to be_within(1.minute).of(Time.zone.now)
+          expect(responseobj.content).to_not be_nil
+          expect(responseobj.values).to eq('v1' => 'true', 'csrf_failed' => 'true')
+        end
       end
     end
 

--- a/spec/controllers/questionnaire_controller_spec.rb
+++ b/spec/controllers/questionnaire_controller_spec.rb
@@ -226,6 +226,19 @@ RSpec.describe QuestionnaireController, type: :controller do
         expect(responseobj.content).to_not be_nil
         expect(responseobj.values).to eq('v1' => 'true')
       end
+
+      it 'logs an attention message and adds a key to the answers when authenticity token fails' do
+        expect_any_instance_of(described_class).to receive(:verify_cookie)
+        protocol_subscription = FactoryBot.create(:protocol_subscription, start_date: 1.week.ago.at_beginning_of_day)
+        responseobj = FactoryBot.create(:response, protocol_subscription: protocol_subscription, open_from: 1.hour.ago)
+        expect(Rails.logger).to receive(:warn).with(/^\[Attention\]/)
+        post :create, params: { response_id: responseobj.id, content: { 'v1' => 'true' }, authenticity_token: 'lol' }
+        expect(response).to have_http_status(302)
+        responseobj.reload
+        expect(responseobj.completed_at).to be_within(1.minute).of(Time.zone.now)
+        expect(responseobj.content).to_not be_nil
+        expect(responseobj.values).to eq('v1' => 'true', 'csrf_failed' => 'true')
+      end
     end
 
     describe 'redirecting with mentor' do


### PR DESCRIPTION
# Description of feature
Logs an [Attention] warn message to the Rails logger and adds a `csrf_failed: true` answer to the questionnaire answer but still stores the answer when a csrf error is detected (only for questionnaire_controller: create).

# Checklist
- [x] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [x] Added unit tests to test the code.
- [x] Added integration tests to test the code within the application as a whole.
